### PR TITLE
Add sprockets require directive

### DIFF
--- a/vendor/assets/javascripts/jquery.ui.touch-punch.js
+++ b/vendor/assets/javascripts/jquery.ui.touch-punch.js
@@ -1,3 +1,5 @@
+//= require jquery.ui.mouse
+
 /*!
  * jQuery UI Touch Punch 0.2.2
  *


### PR DESCRIPTION
If require directive in jquery.ui.touch-punch, I can use `require jquery.ui.touch-punch` before `require jquery.ui.selectable`.
