### PR TITLE
enable rails 4.1

### DIFF
--- a/touchpunch-rails.gemspec
+++ b/touchpunch-rails.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "railties", ">= 3.1", "< 4.1"
+  gem.add_dependency "railties", ">= 3.1"
 end


### PR DESCRIPTION
Is there a reason why to stick to rails < 4.1? As fare a I saw there are no changes in rails 4.1 that should conflict with touchpunch-rails.
